### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/convert-drawio-to-svg.yml
+++ b/.github/workflows/convert-drawio-to-svg.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   convert-drawio:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/architecture-documentation/security/code-scanning/1](https://github.com/Informasjonsforvaltning/architecture-documentation/security/code-scanning/1)

In general, the fix is to add a `permissions` block to the workflow (at the root, or under the specific job) that grants only the scopes required. This documents the workflow’s needs and prevents it from inheriting overly broad repository or organization defaults.

For this workflow, the `convert-drawio` job checks out the repo and then commits and pushes generated `.svg` files. That requires `contents: write` on `GITHUB_TOKEN`; no other scopes (issues, pull-requests, packages, etc.) are needed. The safest and simplest fix without altering behavior is to add `permissions: contents: write` at the job level, just under `runs-on: ubuntu-latest`. This constrains the token for that job only and keeps the current commit/push behavior working.

Concretely, in `.github/workflows/convert-drawio-to-svg.yml`, edit the `convert-drawio` job definition by inserting:

```yaml
    permissions:
      contents: write
```

between `runs-on: ubuntu-latest` (line 9) and `steps:` (line 11). No new imports or external dependencies are needed, and no changes to the existing steps or `GITHUB_TOKEN` usage are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
